### PR TITLE
Point to Jenkins demo image on DockerHub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
      - "9000:9000"
      - "9092:9092"
   jenkins:
-    image: iflowfor8hours/jenkins2
+    image: iflowfor8hours/jenkins2-pipeline-demo
     ports:
      - "8080:8080"
      - "50000:50000"


### PR DESCRIPTION
Docker compose wouldn't work unless I changed your Docker Hub reference to the one that I see on your profile. Took a stab at what I thought would work to fix it.

```
Digest: sha256:88845581b9d2ece8822c610f3430769d638298784a421186fe41850a7311bd31
Status: Downloaded newer image for sonarqube:latest
Pulling jenkins (iflowfor8hours/jenkins2:latest)...
Pulling repository docker.io/iflowfor8hours/jenkins2
ERROR: Error: image iflowfor8hours/jenkins2:latest not found
```
